### PR TITLE
[PDS-33/infra] CORS 설정

### DIFF
--- a/src/main/java/com/example/pladialmserver/global/config/WebConfig.java
+++ b/src/main/java/com/example/pladialmserver/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.example.pladialmserver.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // url 패턴
+                .allowedOrigins("*")
+                // todo: server url 생성 시 변경 필요
+//                .allowedOrigins("url:8080", "http://localhost:8080")
+                .allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PATCH.name(), HttpMethod.DELETE.name()) // 허용 method
+                .allowedHeaders("Authorization", "Content-Type"); // 허용 header
+    }
+}

--- a/src/main/java/com/example/pladialmserver/global/config/WebConfig.java
+++ b/src/main/java/com/example/pladialmserver/global/config/WebConfig.java
@@ -14,7 +14,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins("*")
                 // todo: server url 생성 시 변경 필요
 //                .allowedOrigins("url:8080", "http://localhost:8080")
-                .allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PATCH.name(), HttpMethod.DELETE.name()) // 허용 method
+                .allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PATCH.name(), HttpMethod.DELETE.name(), HttpMethod.OPTIONS.name()) // 허용 method
                 .allowedHeaders("Authorization", "Content-Type"); // 허용 header
     }
 }


### PR DESCRIPTION
## ✈️ 지라 티켓
- [PDS-33](https://pladi-alm.atlassian.net/browse/PDS-33) CORS 설정

<br>

## 👾 작업 내용
- CORS 설정

<br>

## 📸 스크린샷
<img width="471" alt="스크린샷 2023-09-24 오후 8 12 48" src="https://github.com/PLADI-ALM/PLADI-ALM-Server/assets/90203250/fde1630a-0165-4d7c-9b53-086f5dd849d7">


<br>

## 🎸 기타 사항
- 프론트 분들이 쿠키나 다른 기타 작업을 필요로 하신다면 [다음 링크](https://velog.io/@yoonuk/Spring-Boot-CORS-%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0)를 확인 후 설정 추가해주시면 됩니다. (잘 적혀있더라구요)
- allowedOrigins은 서버 url 이 생성된 이후에 url, 및 로컬테스트를 위한 localhost를 추가해서 넣어주시면 됩니다! @dangnak2 
- 허용 메소드는 아래 코드 이외에 더 필요할까요.,.?


[PDS-33]: https://pladi-alm.atlassian.net/browse/PDS-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ