### PR TITLE
[PDS-14/feat] 회의실 예약 API QueryDsl 변경 및 회의실예약/회의실 예약 취소 API 스웨거 설정

### DIFF
--- a/src/main/java/com/example/pladialmserver/booking/controller/BookingController.java
+++ b/src/main/java/com/example/pladialmserver/booking/controller/BookingController.java
@@ -6,6 +6,7 @@ import com.example.pladialmserver.booking.service.BookingService;
 import com.example.pladialmserver.global.response.ResponseCustom;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -46,8 +47,16 @@ public class BookingController {
     /**
      * 회의실 예약 취소
      */
+    @Operation(summary = "회의실 예약 취소", description = "회의실 예약을 취소한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "(S0001)회의실 에약 취소 성공", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
+            @ApiResponse(responseCode = "403", description = "(G0002)접근권한이 없습니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
+            @ApiResponse(responseCode = "404", description = "(B0006)존재하지 않는 예약입니다. (U0001)사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
+            @ApiResponse(responseCode = "409", description = "(B0007)이미 취소된 예약입니다. (B0008)이미 사용이 완료된 예약입니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class)))
+    })
     @PatchMapping("/offices/{officeBookingId}")
-    public ResponseCustom cancelBookingOffice(@PathVariable(name = "officeBookingId") Long officeBookingId) {
+    public ResponseCustom cancelBookingOffice(
+            @Parameter(description = "(Long) 회의실 예약 Id", example = "1") @PathVariable(name = "officeBookingId") Long officeBookingId) {
         bookingService.cancelBookingOffice(officeBookingId);
         return ResponseCustom.OK();
     }

--- a/src/main/java/com/example/pladialmserver/booking/repository/OfficeBookingCustom.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/OfficeBookingCustom.java
@@ -5,6 +5,10 @@ import com.example.pladialmserver.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+
 public interface OfficeBookingCustom {
     Page<BookingRes> getBookingsByUser(User user, Pageable pageable);
+    Boolean existsByDateAndTime(LocalDate date, LocalTime startTime, LocalTime endTime);
 }

--- a/src/main/java/com/example/pladialmserver/booking/repository/OfficeBookingRepository.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/OfficeBookingRepository.java
@@ -1,7 +1,7 @@
 package com.example.pladialmserver.booking.repository;
 
-import com.example.pladialmserver.office.entity.Office;
 import com.example.pladialmserver.booking.entity.OfficeBooking;
+import com.example.pladialmserver.office.entity.Office;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,10 +15,6 @@ import java.util.List;
 public interface OfficeBookingRepository extends JpaRepository<OfficeBooking, Long>, OfficeBookingCustom {
     @Query("SELECT ob FROM OfficeBooking ob WHERE ob.date = :date AND ((ob.startTime <= :startTime AND ob.endTime > :startTime) OR (ob.startTime < :endTime AND ob.endTime >= :endTime))")
     List<OfficeBooking> findByDateAndTime(@Param("date") LocalDate date, @Param("startTime") LocalTime startTime, @Param("endTime") LocalTime endTime);
-
-    // todo: querydsl 로 코드 수정 예정
-    @Query("SELECT count(ob.officeBookingId) > 0 FROM OfficeBooking ob WHERE ob.date = :date AND ((ob.startTime <= :startTime AND ob.endTime > :startTime) OR (ob.startTime < :endTime AND ob.endTime >= :endTime))")
-    Boolean existsByDateAndTime(@Param("date") LocalDate date, @Param("startTime") LocalTime startTime, @Param("endTime") LocalTime endTime);
 
     List<OfficeBooking> findByOfficeAndDate(Office office, LocalDate date);
 }

--- a/src/main/java/com/example/pladialmserver/booking/repository/OfficeBookingRepositoryImpl.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/OfficeBookingRepositoryImpl.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,5 +35,16 @@ public class OfficeBookingRepositoryImpl implements OfficeBookingCustom{
         int start = (int) pageable.getOffset();
         int end = Math.min((start + pageable.getPageSize()), res.size());
         return new PageImpl<>(res.subList(start, end), pageable, res.size());
+    }
+
+    @Override
+    public Boolean existsByDateAndTime(LocalDate date, LocalTime startTime, LocalTime endTime) {
+        Integer fetchOne = jpaQueryFactory.selectOne()
+                .from(officeBooking)
+                .where(officeBooking.date.eq(date)
+                        .and(officeBooking.startTime.loe(startTime).and(officeBooking.endTime.gt(startTime)))
+                        .or(officeBooking.startTime.lt(endTime).and(officeBooking.endTime.goe(endTime))))
+                .fetchFirst();
+        return fetchOne != null;
     }
 }

--- a/src/main/java/com/example/pladialmserver/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/pladialmserver/global/config/SwaggerConfig.java
@@ -19,6 +19,10 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -38,6 +42,10 @@ public class SwaggerConfig {
                 .additionalModels(
                         typeResolver.resolve(ResponseCustom.class)
                 )
+                .directModelSubstitute(LocalDateTime.class, String.class)
+                .directModelSubstitute(LocalDate.class, String.class)
+                .directModelSubstitute(LocalTime.class, String.class)
+                .directModelSubstitute(ZonedDateTime.class, String.class)
                 .apiInfo(apiInfo())
                 .securityContexts(Arrays.asList(securityContext()))
                 .securitySchemes(Arrays.asList(apiKey()))

--- a/src/main/java/com/example/pladialmserver/office/controller/OfficeController.java
+++ b/src/main/java/com/example/pladialmserver/office/controller/OfficeController.java
@@ -88,7 +88,7 @@ public class OfficeController {
      */
     @Operation(summary = "회의실 예약", description = "회의실을 예약한다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "(S0001)회의실 목록 조회 성공", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
+            @ApiResponse(responseCode = "200", description = "(S0001)회의실 예약 성공", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
             @ApiResponse(responseCode = "400", description = "(B0001)날짜와 시간을 모두 입력해주세요. (B0002) 요청사항은 30자 이하로 작성해주세요. (B0003)시작시간보다 끝나는 시간이 더 앞에 있습니다. (B0004)미래의 날짜를 선택해주세요.", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
             @ApiResponse(responseCode = "404", description = "(O0001)존재하지 않는 회의실입니다. (U0001)사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
             @ApiResponse(responseCode = "409", description = "(B0005)이미 예약되어 있는 시간입니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class)))

--- a/src/main/java/com/example/pladialmserver/office/controller/OfficeController.java
+++ b/src/main/java/com/example/pladialmserver/office/controller/OfficeController.java
@@ -9,6 +9,7 @@ import com.example.pladialmserver.office.dto.response.OfficeRes;
 import com.example.pladialmserver.office.service.OfficeService;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -63,7 +64,7 @@ public class OfficeController {
     @Operation(summary = "회의실 개별 조회", description = "회의실 개별 조회를 진행한다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "(S0001)회의실 목록 조회 성공", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
-            @ApiResponse(responseCode = "400", description = "(O0001)존재하지 않는 회의실입니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
+            @ApiResponse(responseCode = "404", description = "(O0001)존재하지 않는 회의실입니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
     })
     @GetMapping("/{officeId}")
     public ResponseCustom<OfficeRes> getOffice(@PathVariable(name="officeId") Long officeId){
@@ -85,9 +86,17 @@ public class OfficeController {
     /**
      * 회의실 예약
      */
+    @Operation(summary = "회의실 예약", description = "회의실을 예약한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "(S0001)회의실 목록 조회 성공", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
+            @ApiResponse(responseCode = "400", description = "(B0001)날짜와 시간을 모두 입력해주세요. (B0002) 요청사항은 30자 이하로 작성해주세요. (B0003)시작시간보다 끝나는 시간이 더 앞에 있습니다. (B0004)미래의 날짜를 선택해주세요.", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
+            @ApiResponse(responseCode = "404", description = "(O0001)존재하지 않는 회의실입니다. (U0001)사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
+            @ApiResponse(responseCode = "409", description = "(B0005)이미 예약되어 있는 시간입니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class)))
+    })
     @PostMapping("/{officeId}/booking")
-    public ResponseCustom bookOffice(@PathVariable(name = "officeId") Long officeId,
-                                     @RequestBody @Valid OfficeReq officeReq){
+    public ResponseCustom bookOffice(
+            @Parameter(description = "(Long) 회의실 Id", example = "1") @PathVariable(name = "officeId") Long officeId,
+            @RequestBody @Valid OfficeReq officeReq){
         // 현재보다 과거 날짜로 등록하는 경우
         if(LocalDate.now().isAfter(officeReq.getDate())) throw new BaseException(BaseResponseCode.DATE_MUST_BE_THE_FUTURE);
         // 끝나는 시간이 시작시간보다 빠른경우

--- a/src/main/java/com/example/pladialmserver/office/dto/request/OfficeReq.java
+++ b/src/main/java/com/example/pladialmserver/office/dto/request/OfficeReq.java
@@ -1,5 +1,6 @@
 package com.example.pladialmserver.office.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -19,15 +20,19 @@ import static com.example.pladialmserver.global.Constants.TIME_PATTERN;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OfficeReq {
+    @Schema(type = "LocalDate(String)", description = "예약일자", example = "2023-09-02", required = true, pattern = DATE_PATTERN)
     @NotNull(message = "B0001")
     @DateTimeFormat(pattern = DATE_PATTERN)
     private LocalDate date;
+    @Schema(type = "LocalTime(String)", description = "예약시작시간", example = "11:00", required = true, pattern = TIME_PATTERN)
     @NotNull(message = "B0001")
     @DateTimeFormat(pattern = TIME_PATTERN)
     private LocalTime startTime;
+    @Schema(type = "LocalTime(String)", description = "예약종료시간", example = "12:00", required = true, pattern = TIME_PATTERN)
     @NotNull(message = "B0001")
     @DateTimeFormat(pattern = TIME_PATTERN)
     private LocalTime endTime;
+    @Schema(type = "String", description = "이용목적", maxLength = 30)
     @Size(max = 30, message = "B0002")
     private String memo;
 }


### PR DESCRIPTION
## ✈️ 지라 티켓
- [PDS-14](https://pladi-alm.atlassian.net/browse/PDS-14) 회의실 예약 API QueryDsl 변경 및 회의실예약/회의실 예약 취소 API 스웨거 설정

<br>

## 👾 작업 내용
- 회의실 예약 API QueryDsl 변경
- 회의실예약/회의실 예약 취소 API 스웨거 설정

<br>

## 📸 스크린샷
회의실 예약에서 LocalTime 부분이 다음과 같이 보여서, Swagger 설정 추가해두었습니다.
=> 원래는 이랬는데
<img width="228" alt="스크린샷 2023-09-25 오후 7 02 28" src="https://github.com/PLADI-ALM/PLADI-ALM-Server/assets/90203250/e357cd17-720e-4794-99a9-d8a3c2d74d82">
<br> => 이렇게 <br>
<img width="273" alt="스크린샷 2023-09-25 오후 7 21 32" src="https://github.com/PLADI-ALM/PLADI-ALM-Server/assets/90203250/2294cd32-12c2-4e0d-8532-42aa08abb730">


<br>

## 🎸 기타 사항
- 


[PDS-14]: https://pladi-alm.atlassian.net/browse/PDS-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ