### PR TITLE
[PDS-82/feat] 레디스 초기 설정 및 로그아웃 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/pladialmserver/booking/controller/BookingController.java
+++ b/src/main/java/com/example/pladialmserver/booking/controller/BookingController.java
@@ -4,7 +4,9 @@ import com.example.pladialmserver.booking.dto.response.BookingRes;
 import com.example.pladialmserver.booking.dto.response.OfficeBookingDetailRes;
 import com.example.pladialmserver.booking.dto.response.ResourceBookingDetailRes;
 import com.example.pladialmserver.booking.service.BookingService;
+import com.example.pladialmserver.global.resolver.Account;
 import com.example.pladialmserver.global.response.ResponseCustom;
+import com.example.pladialmserver.user.entity.User;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -72,8 +74,9 @@ public class BookingController {
     })
     @PatchMapping("/offices/{officeBookingId}/cancel")
     public ResponseCustom cancelBookingOffice(
+            @Account User user,
             @Parameter(description = "(Long) 회의실 예약 Id", example = "1") @PathVariable(name = "officeBookingId") Long officeBookingId) {
-        bookingService.cancelBookingOffice(officeBookingId);
+        bookingService.cancelBookingOffice(user, officeBookingId);
         return ResponseCustom.OK();
     }
 
@@ -107,9 +110,10 @@ public class BookingController {
     })
     @PatchMapping("/resources/{resourceBookingId}/return")
     public ResponseCustom returnBookingResource(
+            @Account User user,
             @Parameter(description = "(Long) 자원 예약 Id", example = "1") @PathVariable(name = "resourceBookingId") Long resourceBookingId
     ){
-        bookingService.returnBookingResource(resourceBookingId);
+        bookingService.returnBookingResource(user, resourceBookingId);
         return ResponseCustom.OK();
     }
 
@@ -126,9 +130,10 @@ public class BookingController {
     })
     @PatchMapping("/resources/{resourceBookingId}/cancel")
     public ResponseCustom cancelBookingResource(
+            @Account User user,
             @Parameter(description = "(Long) 자원 예약 Id", example = "1") @PathVariable(name = "resourceBookingId") Long resourceBookingId
     ){
-        bookingService.cancelBookingResource(resourceBookingId);
+        bookingService.cancelBookingResource(user, resourceBookingId);
         return ResponseCustom.OK();
     }
 }

--- a/src/main/java/com/example/pladialmserver/booking/service/BookingService.java
+++ b/src/main/java/com/example/pladialmserver/booking/service/BookingService.java
@@ -71,10 +71,7 @@ public class BookingService {
      * 회의실 예약 취소
      */
     @Transactional
-    public void cancelBookingOffice(Long officeBookingId) {
-        // todo: 로그인 기능 생성 후 변경 예정
-        User user = userRepository.findById(1L)
-                .orElseThrow(() -> new BaseException(BaseResponseCode.USER_NOT_FOUND));
+    public void cancelBookingOffice(User user, Long officeBookingId) {
         OfficeBooking officeBooking = officeBookingRepository.findById(officeBookingId)
                 .orElseThrow(() -> new BaseException(BaseResponseCode.BOOKING_NOT_FOUND));
 
@@ -128,10 +125,7 @@ public class BookingService {
      * 자원 예약 취소
      */
     @Transactional
-    public void cancelBookingResource(Long resourceBookingId) {
-        // todo: 로그인 기능 생성 후 변경 예정
-        User user = userRepository.findById(1L)
-                .orElseThrow(() -> new BaseException(BaseResponseCode.USER_NOT_FOUND));
+    public void cancelBookingResource(User user, Long resourceBookingId) {
         ResourceBooking resourceBooking = resourceBookingRepository.findById(resourceBookingId)
                 .orElseThrow(() -> new BaseException(BaseResponseCode.BOOKING_NOT_FOUND));
 
@@ -148,9 +142,7 @@ public class BookingService {
     }
 
     @Transactional
-    public void returnBookingResource(Long resourceBookingId) {
-        User user = userRepository.findById(1L)
-                .orElseThrow(() -> new BaseException(BaseResponseCode.USER_NOT_FOUND));
+    public void returnBookingResource(User user, Long resourceBookingId) {
         ResourceBooking resourceBooking = resourceBookingRepository.findById(resourceBookingId)
                 .orElseThrow(() -> new BaseException(BaseResponseCode.BOOKING_NOT_FOUND));
 

--- a/src/main/java/com/example/pladialmserver/global/Constants.java
+++ b/src/main/java/com/example/pladialmserver/global/Constants.java
@@ -13,5 +13,7 @@ public class Constants {
         public static final String AUTHORIZATION_HEADER = "Authorization";
         public static final String BEARER_PREFIX = "bearer ";
         public static final String CLAIM_NAME = "userIdx";
+        public static final String LOGOUT = "logout";
+        public static final String SIGNOUT = "signout";
     }
 }

--- a/src/main/java/com/example/pladialmserver/global/config/RedisConfig.java
+++ b/src/main/java/com/example/pladialmserver/global/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.example.pladialmserver.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Value("${redis.host}")
+    private String host;
+    @Value("${redis.port}")
+    private Integer port;
+    @Value("${redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/pladialmserver/global/exception/BaseResponseCode.java
+++ b/src/main/java/com/example/pladialmserver/global/exception/BaseResponseCode.java
@@ -23,6 +23,7 @@ public enum BaseResponseCode {
     MALFORMED_TOKEN("T0004", HttpStatus.UNAUTHORIZED, "잘못된 구조의 토큰 값입니다."),
     EXPIRED_TOKEN("T0005", HttpStatus.FORBIDDEN, "만료된 토큰 값입니다."),
     NOT_ACCESS_HEADER("T0006", HttpStatus.INTERNAL_SERVER_ERROR, "헤더에 접근할 수 없습니다."),
+    BLACKLIST_TOKEN("T0007", HttpStatus.FORBIDDEN, "로그아웃 혹은 회원 탈퇴된 토큰입니다."),
 
 
     // User

--- a/src/main/java/com/example/pladialmserver/global/resolver/LoginResolver.java
+++ b/src/main/java/com/example/pladialmserver/global/resolver/LoginResolver.java
@@ -4,11 +4,13 @@ import com.example.pladialmserver.global.Constants;
 import com.example.pladialmserver.global.exception.BaseException;
 import com.example.pladialmserver.global.exception.BaseResponseCode;
 import com.example.pladialmserver.global.utils.JwtUtil;
+import com.example.pladialmserver.global.utils.RedisUtil;
 import com.example.pladialmserver.user.entity.User;
 import com.example.pladialmserver.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -36,7 +38,8 @@ public class LoginResolver implements HandlerMethodArgumentResolver {
         token = token.replace(Constants.JWT.BEARER_PREFIX, "");
         // 유효성 검사
         jwtUtil.validateToken(token);
-        // todo : redis blacklist 토큰 확인 필요
+        // 이미 로그아웃 & 회원 탈퇴가 된 토큰인지 확인
+        if(!ObjectUtils.isEmpty(jwtUtil.getTokenInRedis(token))) throw new BaseException(BaseResponseCode.BLACKLIST_TOKEN);
         return userRepository.findById(jwtUtil.getUserIdFromJWT(token)).orElseThrow(() -> new BaseException(BaseResponseCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/pladialmserver/global/utils/JwtUtil.java
+++ b/src/main/java/com/example/pladialmserver/global/utils/JwtUtil.java
@@ -49,7 +49,6 @@ public class JwtUtil {
 
     // Token 기본 생성 및 RefreshToken 생성
     private JwtBuilder createToken(long now, long expireTime) {
-        // todo redis refresh token 적용
         return Jwts.builder()
                 .setExpiration(new Date(now + expireTime))
                 .signWith(key, SignatureAlgorithm.HS256);
@@ -86,5 +85,10 @@ public class JwtUtil {
     public Long getUserIdFromJWT(String accessToken) {
         String userId = String.valueOf(parseClaims(accessToken).get(CLAIM_NAME));
         return Long.parseLong(userId);
+    }
+
+    // redis 내 token 가져오기
+    public String getTokenInRedis(String token){
+        return redisUtil.getValue(token);
     }
 }

--- a/src/main/java/com/example/pladialmserver/global/utils/RedisUtil.java
+++ b/src/main/java/com/example/pladialmserver/global/utils/RedisUtil.java
@@ -1,0 +1,32 @@
+package com.example.pladialmserver.global.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RedisUtil {
+    private final RedisTemplate<String, String> redisTemplate;
+    public void setValue(String key, String value, Duration time) {
+        redisTemplate.opsForValue().set(key, value, time);
+    }
+
+    public void setValue(String key, String value, Long exp, TimeUnit time){
+        redisTemplate.opsForValue().set(key, value, exp, time);
+    }
+
+    public String getValue(String key){
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    @Transactional
+    public void deleteValue(String key){
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/example/pladialmserver/office/controller/OfficeController.java
+++ b/src/main/java/com/example/pladialmserver/office/controller/OfficeController.java
@@ -2,11 +2,13 @@ package com.example.pladialmserver.office.controller;
 
 import com.example.pladialmserver.global.exception.BaseException;
 import com.example.pladialmserver.global.exception.BaseResponseCode;
+import com.example.pladialmserver.global.resolver.Account;
 import com.example.pladialmserver.global.response.ResponseCustom;
 import com.example.pladialmserver.office.dto.request.OfficeReq;
 import com.example.pladialmserver.office.dto.response.BookingStateRes;
 import com.example.pladialmserver.office.dto.response.OfficeRes;
 import com.example.pladialmserver.office.service.OfficeService;
+import com.example.pladialmserver.user.entity.User;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -100,13 +102,14 @@ public class OfficeController {
     })
     @PostMapping("/{officeId}/booking")
     public ResponseCustom bookOffice(
+            @Account User user,
             @Parameter(description = "(Long) 회의실 Id", example = "1") @PathVariable(name = "officeId") Long officeId,
             @RequestBody @Valid OfficeReq officeReq){
         // 현재보다 과거 날짜로 등록하는 경우
         if(LocalDate.now().isAfter(officeReq.getDate())) throw new BaseException(BaseResponseCode.DATE_MUST_BE_THE_FUTURE);
         // 끝나는 시간이 시작시간보다 빠른경우
         if (!officeReq.getStartTime().isBefore(officeReq.getEndTime()) && !officeReq.getEndTime().equals(LocalTime.MIDNIGHT)) throw new BaseException(BaseResponseCode.START_TIME_MUST_BE_IN_FRONT);
-        officeService.bookOffice(officeId, officeReq);
+        officeService.bookOffice(user, officeId, officeReq);
         return ResponseCustom.OK();
     }
 

--- a/src/main/java/com/example/pladialmserver/office/service/OfficeService.java
+++ b/src/main/java/com/example/pladialmserver/office/service/OfficeService.java
@@ -89,10 +89,7 @@ public class OfficeService {
      * 회의실 예약하기
      */
     @Transactional
-    public void bookOffice(Long officeId, OfficeReq officeReq) {
-        // todo: user 로직 생성 후 변경 예정
-        User user = userRepository.findById(1L)
-                .orElseThrow(() -> new BaseException(BaseResponseCode.USER_NOT_FOUND));
+    public void bookOffice(User user, Long officeId, OfficeReq officeReq) {
         Office office = officeRepository.findByOfficeId(officeId)
                 .orElseThrow(() -> new BaseException(BaseResponseCode.OFFICE_NOT_FOUND));
 

--- a/src/main/java/com/example/pladialmserver/user/controller/UserController.java
+++ b/src/main/java/com/example/pladialmserver/user/controller/UserController.java
@@ -62,7 +62,7 @@ public class UserController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "(S0001)로그아웃 성공"),
     })
-    @PostMapping("/position")
+    @PostMapping("/logout")
     public ResponseCustom logout(@Account User user, HttpServletRequest request){
         userService.logout(user, request);
         return ResponseCustom.OK();

--- a/src/main/java/com/example/pladialmserver/user/controller/UserController.java
+++ b/src/main/java/com/example/pladialmserver/user/controller/UserController.java
@@ -14,11 +14,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 
@@ -31,7 +29,7 @@ public class UserController {
     private final UserService userService;
 
     /**
-     * 로그인
+     * [토큰 X] 로그인
      */
     @Operation(summary = "로그인", description = "로그인을 한다.")
     @ApiResponses(value = {
@@ -55,5 +53,18 @@ public class UserController {
     @GetMapping("/position")
     public ResponseCustom<UserPositionRes> getUserPosition(@Account User user){
         return ResponseCustom.OK(userService.getUserPosition(user));
+    }
+
+    /**
+     * 로그아웃
+     */
+    @Operation(summary = "로그아웃", description = "로그아웃을 진행한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "(S0001)로그아웃 성공"),
+    })
+    @PostMapping("/position")
+    public ResponseCustom logout(@Account User user, HttpServletRequest request){
+        userService.logout(user, request);
+        return ResponseCustom.OK();
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,3 +32,8 @@ aws:
   s3:
     region: ENC(g5tyuGOJBDEmnezuqqberSvKxUO3sHtm)
     bucket: ENC(xV+R4mKu3wiOHGoDKhWrsRyXTDOauoNy)
+
+redis:
+  host: ENC(wIh6kiQ7W/qgHC1zR1Vb7ZanSpzgLsT7)
+  port: ENC(52XQ9OWXFVilIpOWtV217g==)
+  password: ENC(12sPod7cSJbwOScRscRp3A==)


### PR DESCRIPTION
## ✈️ 지라 티켓
- [PDS-82](https://pladi-alm.atlassian.net/browse/PDS-82) 레디스 초기 설정 및 로그아웃 API

<br>

## 👾 작업 내용
- 레디스 초기 설정 및 로그아웃 API 추가

<br>

## 📸 스크린샷
<img width="1392" alt="스크린샷 2023-10-09 오후 12 51 12" src="https://github.com/PLADI-ALM/PLADI-ALM-Server/assets/90203250/619f7a7e-c73f-4d1f-9ded-3ba491e2d77d">

<br>

## 🎸 기타 사항
- 컴포즈랑 싸워서 이긴 썰푼다.

- 일단 Docker Compose Network 로 배포/Redis 컨테이너끼리 서로 연동은 시켜놨는데, 아마 머지할 때마다 redis가 초기화 될 것 같아요! github action 파일을 수정해서 고치거나 Data를 서버에 저장하고 다시 컨테이너 올릴 때 넣어두는 식으로 해야할 것 같슴니다.
- 로컬 내 yml 파일은 ip로 접속을 하고 있는데, 서버에서는 컨테이너끼리 통신을 진행해야해서 배포 서버 내 yml 파일은 깃허브와 다를 수 있으니 노션 참고해주세요 `(변경되면 말씀드리겟습니다)`


[PDS-82]: https://pladi-alm.atlassian.net/browse/PDS-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ