### PR TITLE
[PDS-98/feat] 직원 탈퇴 API

### DIFF
--- a/src/main/java/com/example/pladialmserver/PladiAlmServerApplication.java
+++ b/src/main/java/com/example/pladialmserver/PladiAlmServerApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
 @EnableAsync
+@EnableJpaAuditing
 @EnableFeignClients(clients = {ArchivingServerClient.class})
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class PladiAlmServerApplication {

--- a/src/main/java/com/example/pladialmserver/booking/repository/officeBooking/OfficeBookingCustom.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/officeBooking/OfficeBookingCustom.java
@@ -16,4 +16,6 @@ public interface OfficeBookingCustom {
     Boolean existsByDateAndTime(LocalDate date, LocalTime startTime, LocalTime endTime);
     List<OfficeBooking> findByStatusAndDateAndEndTime(BookingStatus status);
     List<OfficeBooking> findByStatusAndDateAndStartTime(BookingStatus status);
+
+    void updateBookingStatusForResigning(User user);
 }

--- a/src/main/java/com/example/pladialmserver/booking/repository/officeBooking/OfficeBookingRepositoryImpl.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/officeBooking/OfficeBookingRepositoryImpl.java
@@ -75,14 +75,10 @@ public class OfficeBookingRepositoryImpl implements OfficeBookingCustom{
     public void updateBookingStatusForResigning(User user) {
         jpaQueryFactory.update(officeBooking)
                 .set(officeBooking.status, BookingStatus.CANCELED)
-                .where(officeBooking.user.eq(user).and(checkBookingStatus()))
+                .where(officeBooking.user.eq(user)
+                        .and(officeBooking.status.in(BookingStatus.BOOKED, BookingStatus.USING)))
                 .execute();
         // 영속성 컨텍스트를 DB 에 즉시 반영
         entityManager.flush();
-    }
-
-    private static BooleanExpression checkBookingStatus() {
-        return officeBooking.status.eq(BookingStatus.BOOKED)
-                .or(officeBooking.status.eq(BookingStatus.USING));
     }
 }

--- a/src/main/java/com/example/pladialmserver/booking/repository/officeBooking/OfficeBookingRepositoryImpl.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/officeBooking/OfficeBookingRepositoryImpl.java
@@ -79,7 +79,6 @@ public class OfficeBookingRepositoryImpl implements OfficeBookingCustom{
                 .execute();
         // 영속성 컨텍스트를 DB 에 즉시 반영
         entityManager.flush();
-//        entityManager.clear(); -> 영속성 컨텍스트 캐시에 모든 엔터티를 제거하면 삭제가 안됨
     }
 
     private static BooleanExpression checkBookingStatus() {

--- a/src/main/java/com/example/pladialmserver/booking/repository/officeBooking/OfficeBookingRepositoryImpl.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/officeBooking/OfficeBookingRepositoryImpl.java
@@ -4,22 +4,27 @@ import com.example.pladialmserver.booking.dto.response.BookingRes;
 import com.example.pladialmserver.booking.entity.OfficeBooking;
 import com.example.pladialmserver.global.entity.BookingStatus;
 import com.example.pladialmserver.user.entity.User;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import javax.persistence.EntityManager;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.example.pladialmserver.booking.entity.QOfficeBooking.officeBooking;
+import static com.example.pladialmserver.booking.entity.QResourceBooking.resourceBooking;
 
 @RequiredArgsConstructor
 public class OfficeBookingRepositoryImpl implements OfficeBookingCustom{
     private final JPAQueryFactory jpaQueryFactory;
+    private final EntityManager entityManager;
 
     @Override
     public Page<BookingRes> getBookingsByUser(User user, Pageable pageable) {
@@ -64,5 +69,21 @@ public class OfficeBookingRepositoryImpl implements OfficeBookingCustom{
                         .and(officeBooking.date.eq(LocalDate.now()))
                         .and(officeBooking.startTime.hour().eq(LocalTime.now().getHour())))
                 .fetch();
+    }
+
+    @Override
+    public void updateBookingStatusForResigning(User user) {
+        jpaQueryFactory.update(officeBooking)
+                .set(officeBooking.status, BookingStatus.CANCELED)
+                .where(officeBooking.user.eq(user).and(checkBookingStatus()))
+                .execute();
+        // 영속성 컨텍스트를 DB 에 즉시 반영
+        entityManager.flush();
+//        entityManager.clear(); -> 영속성 컨텍스트 캐시에 모든 엔터티를 제거하면 삭제가 안됨
+    }
+
+    private static BooleanExpression checkBookingStatus() {
+        return officeBooking.status.eq(BookingStatus.BOOKED)
+                .or(officeBooking.status.eq(BookingStatus.USING));
     }
 }

--- a/src/main/java/com/example/pladialmserver/booking/repository/resourceBooking/ResourceBookingCustom.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/resourceBooking/ResourceBookingCustom.java
@@ -13,4 +13,5 @@ public interface ResourceBookingCustom {
     Page<BookingRes> getBookingsByUser(User user, Pageable pageable);
     boolean existsDate(Resource resource, LocalDate startDate, LocalDate endDate);
     List<String> getResourceBookedDate(Resource resource, LocalDate standardDate);
+    void updateBookingStatusForResigning(User user);
 }

--- a/src/main/java/com/example/pladialmserver/booking/repository/resourceBooking/ResourceBookingRepositoryImpl.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/resourceBooking/ResourceBookingRepositoryImpl.java
@@ -79,17 +79,12 @@ public class ResourceBookingRepositoryImpl implements ResourceBookingCustom{
     public void updateBookingStatusForResigning(User user) {
         jpaQueryFactory.update(resourceBooking)
                 .set(resourceBooking.status, BookingStatus.CANCELED)
-                .where(resourceBooking.user.eq(user).and(checkBookingStatus()))
+                .where(resourceBooking.user.eq(user)
+                        .and(resourceBooking.status.in(BookingStatus.WAITING, BookingStatus.BOOKED, BookingStatus.USING)))
                 .execute();
 
         // 영속성 컨텍스트를 DB 에 즉시 반영
         entityManager.flush();
-    }
-
-    private static BooleanExpression checkBookingStatus() {
-        return resourceBooking.status.eq(BookingStatus.WAITING)
-                .or(resourceBooking.status.eq(BookingStatus.BOOKED))
-                .or(resourceBooking.status.eq(BookingStatus.USING));
     }
 
     @Override

--- a/src/main/java/com/example/pladialmserver/global/entityListener/UserEntityListener.java
+++ b/src/main/java/com/example/pladialmserver/global/entityListener/UserEntityListener.java
@@ -1,4 +1,20 @@
 package com.example.pladialmserver.global.entityListener;
 
+import com.example.pladialmserver.booking.repository.officeBooking.OfficeBookingRepository;
+import com.example.pladialmserver.booking.repository.resourceBooking.ResourceBookingRepository;
+import com.example.pladialmserver.global.utils.BeanUtil;
+import com.example.pladialmserver.user.entity.User;
+
+import javax.persistence.PreRemove;
+
 public class UserEntityListener {
+    @PreRemove
+    public void onUpdate(User user){
+        // 회의실 예약 확인 및 예약 취소
+        OfficeBookingRepository officeBookingRepository = BeanUtil.getBean(OfficeBookingRepository.class);
+        officeBookingRepository.updateBookingStatusForResigning(user);
+        // 자원 예약 확인 및 예약 취소
+        ResourceBookingRepository resourceBookingRepository = BeanUtil.getBean(ResourceBookingRepository.class);
+        resourceBookingRepository.updateBookingStatusForResigning(user);
+    }
 }

--- a/src/main/java/com/example/pladialmserver/global/entityListener/UserEntityListener.java
+++ b/src/main/java/com/example/pladialmserver/global/entityListener/UserEntityListener.java
@@ -1,0 +1,4 @@
+package com.example.pladialmserver.global.entityListener;
+
+public class UserEntityListener {
+}

--- a/src/main/java/com/example/pladialmserver/global/utils/BeanUtil.java
+++ b/src/main/java/com/example/pladialmserver/global/utils/BeanUtil.java
@@ -1,0 +1,19 @@
+package com.example.pladialmserver.global.utils;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BeanUtil implements ApplicationContextAware{
+    private static ApplicationContext applicationContext;
+
+    @Override
+    public void setApplicationContext(ApplicationContext act) throws BeansException {
+        applicationContext = act;
+    }
+    public static <T> T getBean(Class<T> tClass){
+        return applicationContext.getBean(tClass);
+    }
+}

--- a/src/main/java/com/example/pladialmserver/user/controller/AdminUserController.java
+++ b/src/main/java/com/example/pladialmserver/user/controller/AdminUserController.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 @Api(tags = "관리자 유저 API")
@@ -91,6 +92,19 @@ public class AdminUserController {
     public ResponseCustom<UserRes> getUserInfo(@Account User user,
                                                      @Parameter(description = "(Long) 변경하려는 사용자 id", example = "1") @PathVariable(name = "userId") Long userId){
         return ResponseCustom.OK(userService.getUserInfo(user, userId));
+    }
+
+    @Operation(summary = "직원 탈퇴 (장채은)", description = "직원을 탈퇴 한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "(S0001)직원 탈퇴  성공"),
+            @ApiResponse(responseCode = "403", description = "(G0002)접근 권한이 없습니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
+            @ApiResponse(responseCode = "404", description = "(U0001)사용자를 찾을 수 없습니다.[관리자 및 직원 모두]", content = @Content(schema = @Schema(implementation = ResponseCustom.class)))
+    })
+    @DeleteMapping("/{userId}")
+    public ResponseCustom resignUser(@Account User user,
+                                     @Parameter(description = "(Long) 삭제하려는 사용자 id", example = "1") @PathVariable(name = "userId") Long userId){
+        userService.resignUser(user, userId);
+        return ResponseCustom.OK();
     }
 
 }

--- a/src/main/java/com/example/pladialmserver/user/controller/UserController.java
+++ b/src/main/java/com/example/pladialmserver/user/controller/UserController.java
@@ -64,7 +64,7 @@ public class UserController {
     })
     @PostMapping("/logout")
     public ResponseCustom logout(@Account User user, HttpServletRequest request){
-        userService.logout(user, request);
+        userService.setExpiredToken(user, request);
         return ResponseCustom.OK();
     }
 }

--- a/src/main/java/com/example/pladialmserver/user/entity/User.java
+++ b/src/main/java/com/example/pladialmserver/user/entity/User.java
@@ -2,6 +2,7 @@ package com.example.pladialmserver.user.entity;
 
 import com.example.pladialmserver.booking.entity.OfficeBooking;
 import com.example.pladialmserver.global.entity.BaseEntity;
+import com.example.pladialmserver.global.entityListener.UserEntityListener;
 import com.example.pladialmserver.user.dto.request.CreateUserReq;
 import com.example.pladialmserver.user.dto.request.UpdateUserReq;
 import lombok.AccessLevel;
@@ -10,6 +11,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -22,7 +25,9 @@ import java.util.List;
 @DynamicUpdate
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-//@Where(clause = "is_enable = true")
+@Where(clause = "is_enable = true")
+@SQLDelete(sql = "UPDATE user SET is_enable = false, update_at = current_timestamp WHERE user_id = ?")
+@EntityListeners(UserEntityListener.class)
 public class User extends BaseEntity {
 
     @Id

--- a/src/main/java/com/example/pladialmserver/user/service/UserService.java
+++ b/src/main/java/com/example/pladialmserver/user/service/UserService.java
@@ -70,7 +70,7 @@ public class UserService {
     @Transactional
     public void createUser(User admin, CreateUserReq createUserReq) {
         // admin 사용자 확인
-        if (!admin.getRole().equals(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
+        if (!admin.checkRole(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
         // 이메일 중복 확인
         if(userRepository.existsByEmail(createUserReq.getEmail())) throw new BaseException(EXISTS_EMAIL);
         // 회원 생성 리소스 접근
@@ -86,7 +86,7 @@ public class UserService {
     @Transactional
     public void updateUser(User admin, Long userId, UpdateUserReq updateUserReq) {
         // admin 사용자 확인
-        if (!admin.getRole().equals(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
+        if (!admin.checkRole(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
         // 정보 변경 사용자 정보 확인
         User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(USER_NOT_FOUND));
         Department department = departmentRepository.findByName(updateUserReq.getDepartment()).orElseThrow(() -> new BaseException(DEPARTMENT_NOT_FOUND));
@@ -106,14 +106,14 @@ public class UserService {
     // 직원 계정 목록 조회
     public Page<UserRes> getUserList(User admin, String name, Pageable pageable) {
         // admin 사용자 확인
-        if (!admin.getRole().equals(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
+        if (!admin.checkRole(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
         return userRepository.findAllByName(name, pageable).map(UserRes::toDto);
     }
 
     // 직원 개별 정보
     public UserRes getUserInfo(User admin, Long userId) {
         // admin 사용자 확인
-        if (!admin.getRole().equals(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
+        if (!admin.checkRole(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
         User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(USER_NOT_FOUND));
         return UserRes.toDto(user);
     }

--- a/src/main/java/com/example/pladialmserver/user/service/UserService.java
+++ b/src/main/java/com/example/pladialmserver/user/service/UserService.java
@@ -54,8 +54,8 @@ public class UserService {
         return UserPositionRes.toDto(user);
     }
 
-    // 로그아웃
-    public void logout(User user, HttpServletRequest request) {
+    // 토큰 만료
+    public void setExpiredToken(User user, HttpServletRequest request) {
         String bearerToken = request.getHeader(Constants.JWT.AUTHORIZATION_HEADER);
         bearerToken = bearerToken.substring(Constants.JWT.BEARER_PREFIX.length());
         jwtUtil.setBlackListToken(bearerToken, Constants.JWT.LOGOUT);
@@ -69,7 +69,6 @@ public class UserService {
     // 직원 등록
     @Transactional
     public void createUser(User admin, CreateUserReq createUserReq) {
-        // admin 사용자 확인
         if (!admin.checkRole(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
         // 이메일 중복 확인
         if(userRepository.existsByEmail(createUserReq.getEmail())) throw new BaseException(EXISTS_EMAIL);
@@ -85,7 +84,6 @@ public class UserService {
     // 직원 수정
     @Transactional
     public void updateUser(User admin, Long userId, UpdateUserReq updateUserReq) {
-        // admin 사용자 확인
         if (!admin.checkRole(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
         // 정보 변경 사용자 정보 확인
         User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(USER_NOT_FOUND));
@@ -105,16 +103,23 @@ public class UserService {
 
     // 직원 계정 목록 조회
     public Page<UserRes> getUserList(User admin, String name, Pageable pageable) {
-        // admin 사용자 확인
         if (!admin.checkRole(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
         return userRepository.findAllByName(name, pageable).map(UserRes::toDto);
     }
 
     // 직원 개별 정보
     public UserRes getUserInfo(User admin, Long userId) {
-        // admin 사용자 확인
         if (!admin.checkRole(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
         User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(USER_NOT_FOUND));
         return UserRes.toDto(user);
+    }
+
+    // 직원 탈퇴
+    @Transactional
+    public void resignUser(User admin, Long userId) {
+        if (!admin.checkRole(Role.ADMIN)) throw new BaseException(NO_AUTHENTICATION);
+        User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+        jwtUtil.deleteRefreshToken(user.getUserId());
+        userRepository.delete(user);
     }
 }


### PR DESCRIPTION
## ✈️ 지라 티켓
- [PDS-98](https://pladi-alm.atlassian.net/browse/PDS-98) 직원 탈퇴 API

<br>

## 👾 작업 내용
- 직원 탈퇴 API + 스웨거 설정

<br>

## 📸 스크린샷
<img width="1391" alt="스크린샷 2023-10-14 오후 5 00 16" src="https://github.com/PLADI-ALM/PLADI-ALM-Server/assets/90203250/972545f6-8277-4fa3-af7c-02f76101ccb4">

<br>

## 🎸 기타 사항
- QueryDSL에서는 update 문을 사용하고 바로 적용하려면 EntityManager 사용해야한대요 (flush 후 clear)
- 근데 flush로 바로적용하고, 엔터티 매니저에 저장된 엔터티들을 clear 하면 update -> delete 시, delete가 안돼서 clear는 따로해두지 않은 상태임니다....
- 나랑 영속성 컨텍스트 공부할 분,,. ㅎ,ㅡ.,.ㅜ


[PDS-98]: https://pladi-alm.atlassian.net/browse/PDS-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ