### PR TITLE
[PDS-132/fix] 관리자 장비 목록 조회 시, isEnable 체크 및 동적 쿼리로 변경

### DIFF
--- a/src/main/java/com/example/pladialmserver/resource/controller/ResourceAdminController.java
+++ b/src/main/java/com/example/pladialmserver/resource/controller/ResourceAdminController.java
@@ -86,7 +86,7 @@ public class ResourceAdminController {
 
 
     /**
-     * 관리자 자원 삭제
+     * 관리자 장비 삭제
      */
     @Operation(summary = "관리자 장비 삭제 (박소정)", description = "관리자가 장비를 삭제한다.")
     @ApiResponses(value = {

--- a/src/main/java/com/example/pladialmserver/resource/dto/response/AdminResourcesRes.java
+++ b/src/main/java/com/example/pladialmserver/resource/dto/response/AdminResourcesRes.java
@@ -30,18 +30,6 @@ public class AdminResourcesRes {
     @Schema(type = "Boolean", description = "활성화 유무", example = "'true' / 'false'")
     private Boolean isActive;
 
-    public static AdminResourcesRes toDto(Resource resource) {
-        return AdminResourcesRes.builder()
-                .resourceId(resource.getResourceId())
-                .name(resource.getName())
-                .location(resource.getLocation())
-                .responsibilityName(resource.getUser().getName())
-                .responsibilityPhone(resource.getUser().getPhone())
-                .description(resource.getDescription())
-                .isActive(resource.getIsActive())
-                .build();
-    }
-
     @QueryProjection
     public AdminResourcesRes(Long resourceId, String name, String location, String responsibilityName, String responsibilityPhone, String description, Boolean isActive) {
         this.resourceId = resourceId;

--- a/src/main/java/com/example/pladialmserver/resource/dto/response/AdminResourcesRes.java
+++ b/src/main/java/com/example/pladialmserver/resource/dto/response/AdminResourcesRes.java
@@ -1,6 +1,7 @@
 package com.example.pladialmserver.resource.dto.response;
 
 import com.example.pladialmserver.resource.entity.Resource;
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,5 +40,16 @@ public class AdminResourcesRes {
                 .description(resource.getDescription())
                 .isActive(resource.getIsActive())
                 .build();
+    }
+
+    @QueryProjection
+    public AdminResourcesRes(Long resourceId, String name, String location, String responsibilityName, String responsibilityPhone, String description, Boolean isActive) {
+        this.resourceId = resourceId;
+        this.name = name;
+        this.location = location;
+        this.responsibilityName = responsibilityName;
+        this.responsibilityPhone = responsibilityPhone;
+        this.description = description;
+        this.isActive = isActive;
     }
 }

--- a/src/main/java/com/example/pladialmserver/resource/repository/ResourceCustom.java
+++ b/src/main/java/com/example/pladialmserver/resource/repository/ResourceCustom.java
@@ -1,0 +1,9 @@
+package com.example.pladialmserver.resource.repository;
+
+import com.example.pladialmserver.resource.dto.response.AdminResourcesRes;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ResourceCustom {
+    Page<AdminResourcesRes> search(String keyword, Pageable pageable);
+}

--- a/src/main/java/com/example/pladialmserver/resource/repository/ResourceRepository.java
+++ b/src/main/java/com/example/pladialmserver/resource/repository/ResourceRepository.java
@@ -10,12 +10,13 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface ResourceRepository extends JpaRepository<Resource, Long> {
+public interface ResourceRepository extends JpaRepository<Resource, Long>, ResourceCustom {
     Page<Resource> findByNameAndResourceIdNotIn(String resourceName, List<Long> resourceIds, Pageable pageable);
 
+    Page<Resource> findByNameContaining(String resourceName, Pageable pageable);
 
-    Page<Resource> findByNameContaining(String resourceName,Pageable pageable);
-    Page<Resource> findByNameContainingOrderByName(String resourceName,Pageable pageable);
+    Page<Resource> findByNameContainingOrderByName(String resourceName, Pageable pageable);
+
     Optional<Resource> findByResourceIdAndIsEnable(Long resourceId, boolean isEnable);
 
 }

--- a/src/main/java/com/example/pladialmserver/resource/repository/ResourceRepositoryImpl.java
+++ b/src/main/java/com/example/pladialmserver/resource/repository/ResourceRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.example.pladialmserver.resource.repository;
+
+import com.example.pladialmserver.resource.dto.response.AdminResourcesRes;
+import com.example.pladialmserver.resource.dto.response.QAdminResourcesRes;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.example.pladialmserver.resource.entity.QResource.resource;
+import static org.springframework.util.StringUtils.hasText;
+
+@RequiredArgsConstructor
+public class ResourceRepositoryImpl implements ResourceCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private BooleanExpression resourceNameContaining(String resourceName) {
+        return hasText(resourceName) ? resource.name.contains(resourceName) : null;
+    }
+
+    @Override
+    public Page<AdminResourcesRes> search(String resourceName, Pageable pageable) {
+        List<AdminResourcesRes> results = jpaQueryFactory
+                .select(new QAdminResourcesRes(
+                        resource.resourceId,
+                        resource.name,
+                        resource.location,
+                        resource.user.name,
+                        resource.user.phone,
+                        resource.description,
+                        resource.isActive)
+                )
+                .from(resource)
+                .where(
+                        resourceNameContaining(resourceName),
+                        resource.isEnable.eq(true)
+                )
+                .orderBy(resource.name.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = results.size();
+        return new PageImpl<>(results, pageable, total);
+    }
+}

--- a/src/main/java/com/example/pladialmserver/resource/service/ResourceService.java
+++ b/src/main/java/com/example/pladialmserver/resource/service/ResourceService.java
@@ -20,7 +20,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -113,17 +112,11 @@ public class ResourceService {
     /**
      * 관리자 장비 목록 조회
      */
-    public Page<AdminResourcesRes> getResourcesByAdmin(User user, String keyword, Pageable pageable) {
+    public Page<AdminResourcesRes> getResourcesByAdmin(User user, String resourceName, Pageable pageable) {
         // 관리자 권한 확인
         checkAdminRole(user);
         // 장비 조회
-        Page<Resource> resources = null;
-        if(!StringUtils.hasText(keyword)) {
-            resources = resourceRepository.findAll(pageable);
-        } else {
-            resources = resourceRepository.findByNameContainingOrderByName(keyword, pageable);
-        }
-        return resources.map(AdminResourcesRes::toDto);
+        return resourceRepository.search(resourceName, pageable);
     }
 
     /**

--- a/src/main/java/com/example/pladialmserver/resource/service/ResourceService.java
+++ b/src/main/java/com/example/pladialmserver/resource/service/ResourceService.java
@@ -43,7 +43,7 @@ public class ResourceService {
 
 
     /**
-     * 전체 자원 목록 조회 and 예약 가능한 자원 목록 조회
+     * 전체 장비 목록 조회 and 예약 가능한 장비 목록 조회
      */
     public Page<ResourceRes> findAvailableResources(String resourceName, LocalDate startDate, LocalDate endDate, Pageable pageable) {
         Page<Resource> allResources;
@@ -78,7 +78,7 @@ public class ResourceService {
 
 
     /**
-     * 자원 기간별 예약 현황 조회
+     * 장비 기간별 예약 현황 조회
      */
     public List<String> getResourceBookedDate(Long resourceId, String month) {
         Resource resource = resourceRepository.findById(resourceId)
@@ -91,7 +91,7 @@ public class ResourceService {
 
 
     /**
-     * 자원 예약
+     * 장비 예약
      */
     // TODO 기획 변경으로 인한 수정
     @Transactional


### PR DESCRIPTION
## ✈️ 지라 티켓
- [PDS-132](https://pladi-alm.atlassian.net/browse/PDS-132) 관리자 장비 목록 조회 시, isEnable 체크 및 동적 쿼리로 변경

<br>

## 👾 작업 내용
- `isEnable=true` 인 것만 조회되도록 수정
- orderBy 이름 오름차순으로 설정
- 동적 쿼리로 변경 
 `@QueryProjection` 사용
 `resourceNameContaining` 메소드 통해 keyword가 유무 따른 동적 쿼리 실행

<br>

## 📸 스크린샷
<img width="481" alt="스크린샷 2023-10-27 오후 2 09 16" src="https://github.com/PLADI-ALM/PLADI-ALM-Server/assets/90022940/9b1bde8e-f4cd-4e5d-8583-f081ad1ddb44">


<br>

## 🎸 기타 사항
- 자원(->장비) 워딩 변경

[PDS-132]: https://pladi-alm.atlassian.net/browse/PDS-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ