### PR TITLE
[PDS-195/test] 구매 장비 등록 API 성공 테스트 구현

### DIFF
--- a/src/main/java/com/example/pladialmserver/equipment/dto/request/RegisterEquipmentReq.java
+++ b/src/main/java/com/example/pladialmserver/equipment/dto/request/RegisterEquipmentReq.java
@@ -1,12 +1,14 @@
 package com.example.pladialmserver.equipment.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Getter;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 
 @Getter
+@Builder
 public class RegisterEquipmentReq {
 
     @Schema(type = "String", description = "이름", example = "맥심커피", required = true)

--- a/src/test/java/com/example/pladialmserver/equipment/controller/EquipmentControllerTest.java
+++ b/src/test/java/com/example/pladialmserver/equipment/controller/EquipmentControllerTest.java
@@ -1,0 +1,21 @@
+package com.example.pladialmserver.equipment.controller;
+
+import org.junit.jupiter.api.Test;
+
+public class EquipmentControllerTest {
+    @Test
+    void registerEquipment() {
+    }
+
+    @Test
+    void searchEquipment() {
+    }
+
+    @Test
+    void updateEquipment() {
+    }
+
+    @Test
+    void deleteEquipment() {
+    }
+}

--- a/src/test/java/com/example/pladialmserver/equipment/service/EquipmentServiceTest.java
+++ b/src/test/java/com/example/pladialmserver/equipment/service/EquipmentServiceTest.java
@@ -1,0 +1,74 @@
+package com.example.pladialmserver.equipment.service;
+
+import com.example.pladialmserver.equipment.dto.request.RegisterEquipmentReq;
+import com.example.pladialmserver.equipment.repository.EquipmentCategoryRepository;
+import com.example.pladialmserver.equipment.repository.EquipmentRepository;
+import com.example.pladialmserver.global.utils.JwtUtil;
+import com.example.pladialmserver.user.entity.User;
+import com.example.pladialmserver.user.repository.user.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static com.example.pladialmserver.equipment.service.model.TestEquipmentInfo.setUpRegisterEquipmentInfo;
+import static com.example.pladialmserver.user.service.model.TestUserInfo.*;
+import static com.example.pladialmserver.user.service.model.TestUserInfo.PASSWORD;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class EquipmentServiceTest {
+
+    @Spy
+    @InjectMocks
+    private EquipmentService equipmentService;
+    @Mock
+    private EquipmentRepository equipmentRepository;
+    @Mock
+    private EquipmentCategoryRepository equipmentCategoryRepository;
+    @Mock
+    BCryptPasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    @DisplayName("[성공] 구매 비품 추가")
+    void registerEquipmentSuccess() {
+        // given
+        User user = setUpUser(setUpDepartment(), setUpAffiliation(), passwordEncoder.encode(PASSWORD));
+        RegisterEquipmentReq req = setUpRegisterEquipmentInfo("맥심커피", "10박스", "기타", "S1305", "맥심커피입니다.", "photo/maxim.png");
+
+        // when
+        equipmentService.registerEquipment(req, user);
+
+        // verify
+        verify(equipmentService, times(1)).registerEquipment(any(RegisterEquipmentReq.class), any(User.class));
+        verify(passwordEncoder, times(1)).encode(any(String.class));
+    }
+
+    @Test
+    void searchEquipment() {
+    }
+
+    @Test
+    void updateEquipment() {
+    }
+
+    @Test
+    void deleteEquipment() {
+    }
+}

--- a/src/test/java/com/example/pladialmserver/equipment/service/model/TestEquipmentInfo.java
+++ b/src/test/java/com/example/pladialmserver/equipment/service/model/TestEquipmentInfo.java
@@ -1,0 +1,18 @@
+package com.example.pladialmserver.equipment.service.model;
+
+import com.example.pladialmserver.equipment.dto.request.RegisterEquipmentReq;
+
+public class TestEquipmentInfo {
+
+    public static RegisterEquipmentReq setUpRegisterEquipmentInfo(String name, String quantity, String category, String location, String description, String imgKey )  {
+        return RegisterEquipmentReq.builder()
+                .name(name)
+                .quantity(quantity)
+                .category(category)
+                .location(location)
+                .description(description)
+                .imgKey(imgKey)
+                .build();
+
+    }
+}


### PR DESCRIPTION
## ✈️ 지라 티켓
- [PDS-195](https://pladi-alm.atlassian.net/browse/PDS-195) 구매 장비 등록 API 성공 테스트 구현

<br>

## 👾 작업 내용
- 구매 장비 등록 API 성공 테스트 구현

<br>

## 📸 스크린샷
<img width="1401" alt="스크린샷 2023-11-23 오후 8 10 10" src="https://github.com/PLADI-ALM/PLADI-ALM-Server/assets/80161984/17e34589-5db7-4039-ac05-d4a99305f180">

<br>

## 🎸 기타 사항
- 장비 등록 리퀘스트 검증은 컨트롤러단에서 진행되기 때문에 실패 케이스는 controller test에서 구현하겠습니다
- 장비 등록 api는 void리턴이라 verify 검증만 구현했습니다
- 이렇게하는거 맞?


[PDS-195]: https://pladi-alm.atlassian.net/browse/PDS-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ