### PR TITLE
[PDS-203/test] 비품 정보 삭제 API 테스트

### DIFF
--- a/src/test/java/com/example/pladialmserver/equipment/service/EquipmentServiceTest.java
+++ b/src/test/java/com/example/pladialmserver/equipment/service/EquipmentServiceTest.java
@@ -14,6 +14,7 @@ import com.example.pladialmserver.user.repository.user.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -101,6 +102,36 @@ class EquipmentServiceTest {
     }
 
     @Test
-    void deleteEquipment() {
+    @DisplayName("[성공] 비품 정보 삭제")
+    void deleteEquipment_SUCCESS() {
+        // given
+        Long equipmentId = 1L;
+        User user = setUpUser(1L, Role.ADMIN, setUpDepartment(), setUpAffiliation(), passwordEncoder.encode(PASSWORD));
+        Equipment equipment = setUpEquipment("비품1", "10개", "photo/maxim.png", "S1350", "비품1입니다.", new EquipmentCategory("기타"), user);
+
+        // when
+        doReturn(Optional.of(equipment)).when(equipmentRepository).findByEquipmentIdAndIsEnable(equipmentId, true);
+        equipmentService.deleteEquipment(equipmentId, user);
+
+        // verify
+        verify(equipmentService, times(1)).deleteEquipment(equipmentId, user);
+    }
+
+    @Test
+    @DisplayName("[실패] 비품 정보 삭제 - 관리자가 아닌 경우")
+    void deleteEquipment_NO_AUTHENTICATION() {
+        // given
+        User admin = setUpUser(1L, Role.ADMIN, setUpDepartment(), setUpAffiliation(), passwordEncoder.encode(PASSWORD));
+        User basic = setUpUser(2L, Role.BASIC, setUpDepartment(), setUpAffiliation(), passwordEncoder.encode(PASSWORD));
+        Equipment equipment = setUpEquipment("비품1", "10개", "photo/maxim.png", "S1350", "비품1입니다.", new EquipmentCategory("기타"), admin);
+
+        // when
+        doReturn(Optional.of(equipment)).when(equipmentRepository).findByEquipmentIdAndIsEnable(equipment.getEquipmentId(), true);
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            equipmentService.deleteEquipment(equipment.getEquipmentId(), basic);
+        });
+
+        // then
+        assertThat(exception.getBaseResponseCode()).isEqualTo(BaseResponseCode.NO_AUTHENTICATION);
     }
 }


### PR DESCRIPTION
## ✈️ 지라 티켓
- [PDS-203](https://pladi-alm.atlassian.net/browse/PDS-203) 비품 정보 삭제 API 테스트

<br>

## 👾 작업 내용
- 비품 정보 삭제 API 테스트 성공
- 비품 정보 삭제 API 테스트 실패 (NO_AUTHENTICATION)

<br>

## 📸 스크린샷
<img width="1440" alt="스크린샷 2023-11-26 오후 8 19 01" src="https://github.com/PLADI-ALM/PLADI-ALM-Server/assets/80161984/7d35a9b7-9d00-4bdd-9d2d-8d959e4cfd8c">

<br>

## 🎸 기타 사항
- x


[PDS-203]: https://pladi-alm.atlassian.net/browse/PDS-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ