### PR TITLE
[PDS-155/fix] 월별 장비/차량 예약 불가능 날짜 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/pladialmserver/booking/repository/carBooking/CarBookingRepositoryImpl.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/carBooking/CarBookingRepositoryImpl.java
@@ -34,7 +34,7 @@ public class CarBookingRepositoryImpl implements CarBookingCustom {
         // 1. 예약중 & 사용중인 날짜들
         List<CarBooking> bookings = jpaQueryFactory.selectFrom(carBooking)
                 .where(carBooking.car.eq(car)
-                        .and(carBooking.status.in(BookingStatus.BOOKED, BookingStatus.USING)))
+                        .and(carBooking.status.notIn(BookingStatus.CANCELED, BookingStatus.FINISHED)))
                 .orderBy(carBooking.startDate.asc())
                 .fetch();
 
@@ -54,7 +54,7 @@ public class CarBookingRepositoryImpl implements CarBookingCustom {
         CarBooking booking = jpaQueryFactory
                 .selectFrom(carBooking)
                 .where(carBooking.car.eq(car),
-                        (carBooking.status.in(BookingStatus.WAITING, BookingStatus.BOOKED, BookingStatus.USING)),
+                        (carBooking.status.notIn(BookingStatus.CANCELED)),
                         (carBooking.startDate.before(standardDate)),
                         (carBooking.endDate.after(standardDate))
                 ).orderBy(carBooking.startDate.asc())
@@ -73,7 +73,7 @@ public class CarBookingRepositoryImpl implements CarBookingCustom {
         // 해당 월의 예약 현황 조회
         List<CarBooking> bookings = jpaQueryFactory.selectFrom(carBooking)
                 .where(carBooking.car.eq(car)
-                        .and(carBooking.status.in(BookingStatus.WAITING, BookingStatus.BOOKED, BookingStatus.USING))
+                        .and(carBooking.status.notIn(BookingStatus.CANCELED))
                         .and(carBooking.startDate.loe(endDateTime)
                                 .and(carBooking.endDate.after(startDateTime))
                                 .or(carBooking.startDate.before(startDateTime).and(carBooking.endDate.after(endDateTime)))
@@ -149,7 +149,7 @@ public class CarBookingRepositoryImpl implements CarBookingCustom {
         // 기준 날짜에 포함된 예약
         List<CarBooking> bookings = jpaQueryFactory.selectFrom(carBooking)
                 .where(carBooking.car.eq(car)
-                        .and(carBooking.status.in(BookingStatus.WAITING, BookingStatus.BOOKED, BookingStatus.USING))
+                        .and(carBooking.status.notIn(BookingStatus.CANCELED))
                         .and(carBooking.startDate.loe(endDateTime)
                                 .and(carBooking.endDate.after(startDateTime))
                                 .or(carBooking.startDate.before(startDateTime).and(carBooking.endDate.after(endDateTime)))
@@ -183,7 +183,7 @@ public class CarBookingRepositoryImpl implements CarBookingCustom {
         // 기준 날짜에 포함된 예약
         List<CarBooking> bookings = jpaQueryFactory.selectFrom(carBooking)
                 .where(carBooking.car.eq(car)
-                        .and(carBooking.status.in(BookingStatus.WAITING, BookingStatus.BOOKED, BookingStatus.USING))
+                        .and(carBooking.status.notIn(BookingStatus.CANCELED))
                         .and(carBooking.startDate.loe(endDateTime)
                                 .and(carBooking.endDate.after(startDateTime))
                                 .or(carBooking.startDate.before(startDateTime).and(carBooking.endDate.after(endDateTime)))

--- a/src/main/java/com/example/pladialmserver/booking/repository/carBooking/CarBookingRepositoryImpl.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/carBooking/CarBookingRepositoryImpl.java
@@ -16,10 +16,10 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
+import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -67,64 +67,47 @@ public class CarBookingRepositoryImpl implements CarBookingCustom {
     public List<String> getCarBookedDate(Car car, LocalDate standardDate) {
         // 해당 월의 첫 날 (00:00)
         LocalDateTime startDateTime = standardDate.withDayOfMonth(1).atStartOfDay();
-        // 다음 월의 첫 날 (00:00)
-        LocalDateTime endDateTime = standardDate.plusMonths(1).atStartOfDay();
+        // 해당 월의 마지막 날 (23:00)
+        LocalDateTime endDateTime = standardDate.withDayOfMonth(standardDate.lengthOfMonth()).atTime(23, 0);
 
         // 해당 월의 예약 현황 조회
         List<CarBooking> bookings = jpaQueryFactory.selectFrom(carBooking)
                 .where(carBooking.car.eq(car)
                         .and(carBooking.status.in(BookingStatus.WAITING, BookingStatus.BOOKED, BookingStatus.USING))
-                        .and((carBooking.startDate.between(startDateTime, endDateTime))
-                                .or(carBooking.endDate.between(startDateTime, endDateTime)))
+                        .and(carBooking.startDate.loe(endDateTime)
+                                .and(carBooking.endDate.after(startDateTime))
+                                .or(carBooking.startDate.before(startDateTime).and(carBooking.endDate.after(endDateTime)))
+                        )
                 ).orderBy(carBooking.startDate.asc())
                 .fetch();
 
-        // 예약이 모두 된 날짜(첫 날 0시 ~ 다음 날 0시) 반환
-        List<String> bookedDate = new ArrayList<>();
-        int index = 0;
-        boolean isContinuity = false;
-        LocalDateTime standard = null;
+        Map<LocalDate, Integer> datesOfMonth = createDatesOfMonth(standardDate.getYear(), standardDate.getMonth());
+        for (LocalDate date : datesOfMonth.keySet()) {
+            List<LocalDateTime> hoursList = IntStream.range(0, 24)
+                    .mapToObj(date.atStartOfDay()::plusHours)
+                    .collect(Collectors.toList());
 
             for (CarBooking b : bookings) {
-                index++;
-
-                // 연속 유무 및 연속 기준일 체크
-                if (index == 1) {
-                    standard = bookings.get(0).getEndDate();
-                    if (isMidnight(bookings.get(0).getStartDate())) isContinuity = true;
-                } else {
-                    isContinuity = (standard.isEqual(b.getStartDate()) || isMidnight(b.getStartDate()));
+                for (LocalDateTime dateTime : hoursList) {
+                    if ((dateTime.isAfter(b.getStartDate()) && dateTime.isBefore(b.getEndDate())) || dateTime.isEqual(b.getStartDate()))
+                        // 시간마다 +1
+                        datesOfMonth.put(date, datesOfMonth.get(date) + 1);
                 }
-
-                // 시작일 & 종료일 다른 경우
-                if (!DateTimeUtil.dateTimeToDate(b.getStartDate()).isEqual(DateTimeUtil.dateTimeToDate(b.getEndDate()))) {
-                    // 연속인 경우 & 다음 날 00시 또는 이상인 경우 -> startDate 더해주기
-                    if (isContinuity &&
-                            b.getEndDate().isAfter(DateTimeUtil.getMidNightDateTime(b.getEndDate().plusDays(1))) || b.getEndDate().isEqual(DateTimeUtil.getMidNightDateTime(b.getEndDate().plusDays(1)))) {
-                        bookedDate.add(DateTimeUtil.dateToString(b.getStartDate().toLocalDate()));
-                    } else if (!isContinuity && ChronoUnit.DAYS.between(b.getStartDate(), b.getEndDate()) == 1) {
-                        break;
-                    } else {
-                        // 중간 날짜 더해주기
-                        List<String> dates = b.getStartDate().toLocalDate().datesUntil(b.getEndDate().toLocalDate())
-                                .map(DateTimeUtil::dateToString)
-                                .collect(Collectors.toList());
-                        bookedDate.addAll(dates);
-                    }
-                }
-                // 시작일 & 종료일 동일한 경우
-                else {
-                    if (!isContinuity && bookings.size() > index)
-                        isContinuity = isMidnight(bookings.get(index).getStartDate());
-                }
-                // 모두 수행
-                standard = b.getEndDate();
             }
-            return bookedDate;
+        }
+
+        return datesOfMonth.entrySet().stream()
+                // 예약이 모두 된 날짜 반환
+                .filter(entry -> entry.getValue() == 24)
+                .map(date -> DateTimeUtil.dateToString(date.getKey()))
+                .sorted()
+                .collect(Collectors.toList());
     }
 
-    private boolean isMidnight(LocalDateTime localDateTime) {
-        return DateTimeUtil.dateTimeToTime(localDateTime).equals(LocalTime.MIN);
+    private Map<LocalDate, Integer> createDatesOfMonth(int year, Month month) {
+        return IntStream.rangeClosed(1, month.maxLength())
+                .mapToObj(day -> LocalDate.of(year, month, day))
+                .collect(Collectors.toMap(date -> date, date -> 0));
     }
 
 

--- a/src/main/java/com/example/pladialmserver/booking/repository/resourceBooking/ResourceBookingRepositoryImpl.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/resourceBooking/ResourceBookingRepositoryImpl.java
@@ -61,7 +61,7 @@ public class ResourceBookingRepositoryImpl implements ResourceBookingCustom {
         // 해당 월의 예약 현황 조회
         List<ResourceBooking> bookings = jpaQueryFactory.selectFrom(resourceBooking)
                 .where(resourceBooking.resource.eq(resource)
-                        .and(resourceBooking.status.in(BookingStatus.WAITING, BookingStatus.BOOKED, BookingStatus.USING))
+                        .and(resourceBooking.status.notIn(BookingStatus.CANCELED))
                         .and(resourceBooking.startDate.loe(endDateTime)
                                 .and(resourceBooking.endDate.after(startDateTime))
                                 .or(resourceBooking.startDate.before(startDateTime).and(resourceBooking.endDate.after(endDateTime)))
@@ -117,7 +117,7 @@ public class ResourceBookingRepositoryImpl implements ResourceBookingCustom {
         ResourceBooking booking = jpaQueryFactory
                 .selectFrom(resourceBooking)
                 .where(resourceBooking.resource.eq(resource),
-                        (resourceBooking.status.in(BookingStatus.WAITING, BookingStatus.BOOKED, BookingStatus.USING)),
+                        (resourceBooking.status.notIn(BookingStatus.CANCELED)),
                         (resourceBooking.startDate.before(standardDate).or(resourceBooking.startDate.eq(standardDate))),
                         (resourceBooking.endDate.after(standardDate))
                 ).orderBy(resourceBooking.startDate.asc())
@@ -133,7 +133,7 @@ public class ResourceBookingRepositoryImpl implements ResourceBookingCustom {
         // 1. 예약중 & 사용중인 날짜들
         List<ResourceBooking> bookings = jpaQueryFactory.selectFrom(resourceBooking)
                 .where(resourceBooking.resource.eq(resource)
-                        .and(resourceBooking.status.in(BookingStatus.BOOKED, BookingStatus.USING)))
+                        .and(resourceBooking.status.notIn(BookingStatus.CANCELED, BookingStatus.FINISHED)))
                 .orderBy(resourceBooking.startDate.asc())
                 .fetch();
 
@@ -143,7 +143,6 @@ public class ResourceBookingRepositoryImpl implements ResourceBookingCustom {
             if (!startDateTime.isBefore(b.getStartDate()) && startDateTime.isBefore(b.getEndDate())) return true;
             if (!endDateTime.isBefore(b.getStartDate()) && endDateTime.isBefore(b.getEndDate())) return true;
         }
-
         return false;
     }
 
@@ -171,7 +170,7 @@ public class ResourceBookingRepositoryImpl implements ResourceBookingCustom {
         // 기준 날짜에 포함된 예약
         List<ResourceBooking> bookings = jpaQueryFactory.selectFrom(resourceBooking)
                 .where(resourceBooking.resource.eq(resource)
-                        .and(resourceBooking.status.in(BookingStatus.WAITING, BookingStatus.BOOKED, BookingStatus.USING))
+                        .and(resourceBooking.status.notIn(BookingStatus.CANCELED))
                         .and(resourceBooking.startDate.loe(endDateTime)
                                 .and(resourceBooking.endDate.after(startDateTime))
                                 .or(resourceBooking.startDate.before(startDateTime).and(resourceBooking.endDate.after(endDateTime)))
@@ -206,7 +205,7 @@ public class ResourceBookingRepositoryImpl implements ResourceBookingCustom {
         // 기준 날짜에 포함된 예약
         List<ResourceBooking> bookings = jpaQueryFactory.selectFrom(resourceBooking)
                 .where(resourceBooking.resource.eq(resource)
-                        .and(resourceBooking.status.in(BookingStatus.WAITING, BookingStatus.BOOKED, BookingStatus.USING))
+                        .and(resourceBooking.status.notIn(BookingStatus.CANCELED))
                         .and(resourceBooking.startDate.loe(endDateTime)
                                 .and(resourceBooking.endDate.after(startDateTime))
                                 .or(resourceBooking.startDate.before(startDateTime).and(resourceBooking.endDate.after(endDateTime)))

--- a/src/main/java/com/example/pladialmserver/booking/repository/resourceBooking/ResourceBookingRepositoryImpl.java
+++ b/src/main/java/com/example/pladialmserver/booking/repository/resourceBooking/ResourceBookingRepositoryImpl.java
@@ -17,10 +17,10 @@ import org.springframework.data.domain.Pageable;
 import javax.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
+import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -50,74 +50,52 @@ public class ResourceBookingRepositoryImpl implements ResourceBookingCustom {
         return new PageImpl<>(res.subList(start, end), pageable, res.size());
     }
 
-//    private BooleanExpression dateContaining(LocalDate date) {
-//        return ObjectUtil.check ?
-//        return hasText(resourceName) ? resource.name.contains(resourceName) : null;
-//    }
-
     // 장비 월별 예약 현황 조회
     @Override
     public List<String> getResourceBookedDate(Resource resource, LocalDate standardDate) {
         // 해당 월의 첫 날 (00:00)
         LocalDateTime startDateTime = standardDate.withDayOfMonth(1).atStartOfDay();
-        // 다음 월의 첫 날 (00:00)
-        LocalDateTime endDateTime = standardDate.plusMonths(1).atStartOfDay();
+        // 해당 월의 마지막 날 (23:00)
+        LocalDateTime endDateTime = standardDate.withDayOfMonth(standardDate.lengthOfMonth()).atTime(23, 0);
 
         // 해당 월의 예약 현황 조회
         List<ResourceBooking> bookings = jpaQueryFactory.selectFrom(resourceBooking)
                 .where(resourceBooking.resource.eq(resource)
                         .and(resourceBooking.status.in(BookingStatus.WAITING, BookingStatus.BOOKED, BookingStatus.USING))
-                        .and((resourceBooking.startDate.between(startDateTime, endDateTime))
-                                    .or(resourceBooking.endDate.between(startDateTime, endDateTime)))
-                    ).orderBy(resourceBooking.startDate.asc())
-                    .fetch();
+                        .and(resourceBooking.startDate.loe(endDateTime)
+                                .and(resourceBooking.endDate.after(startDateTime))
+                                .or(resourceBooking.startDate.before(startDateTime).and(resourceBooking.endDate.after(endDateTime)))
+                        )
+                ).orderBy(resourceBooking.startDate.asc())
+                .fetch();
 
-            // 예약이 모두 된 날짜(첫 날 0시 ~ 다음 날 0시) 반환
-            List<String> bookedDate = new ArrayList<>();
-            int index = 0;
-            boolean isContinuity = false;
-            LocalDateTime standard = null;
+        Map<LocalDate, Integer> datesOfMonth = createDatesOfMonth(standardDate.getYear(), standardDate.getMonth());
+        for (LocalDate date : datesOfMonth.keySet()) {
+            List<LocalDateTime> hoursList = IntStream.range(0, 24)
+                    .mapToObj(date.atStartOfDay()::plusHours)
+                    .collect(Collectors.toList());
 
             for (ResourceBooking b : bookings) {
-                index++;
-
-                // 연속 유무 및 연속 기준일 체크
-                if (index == 1) {
-                    standard = bookings.get(0).getEndDate();
-                    if (isMidnight(bookings.get(0).getStartDate())) isContinuity = true;
-                } else {
-                    isContinuity = (standard.isEqual(b.getStartDate()) || isMidnight(b.getStartDate()));
+                for (LocalDateTime dateTime : hoursList) {
+                    if ((dateTime.isAfter(b.getStartDate()) && dateTime.isBefore(b.getEndDate())) || dateTime.isEqual(b.getStartDate()))
+                        // 시간마다 +1
+                        datesOfMonth.put(date, datesOfMonth.get(date) + 1);
                 }
-
-                // 시작일 & 종료일 다른 경우
-                if (!DateTimeUtil.dateTimeToDate(b.getStartDate()).isEqual(DateTimeUtil.dateTimeToDate(b.getEndDate()))) {
-                    // 연속인 경우 & 다음 날 00시 또는 이상인 경우 -> startDate 더해주기
-                    if (isContinuity &&
-                            b.getEndDate().isAfter(DateTimeUtil.getMidNightDateTime(b.getEndDate().plusDays(1)))
-                            || b.getEndDate().isEqual(DateTimeUtil.getMidNightDateTime(b.getEndDate().plusDays(1)))) {
-                        bookedDate.add(DateTimeUtil.dateToString(b.getStartDate().toLocalDate()));
-                    } else if (!isContinuity && ChronoUnit.DAYS.between(b.getStartDate(), b.getEndDate()) == 1) {
-                        break;
-                    } else {
-                        List<String> dates = b.getStartDate().toLocalDate().datesUntil(b.getEndDate().toLocalDate())
-                                .map(DateTimeUtil::dateToString)
-                                .collect(Collectors.toList());
-                        bookedDate.addAll(dates);
-                    }
-                }
-                // 시작일 & 종료일 동일한 경우
-                else {
-                    if (!isContinuity && bookings.size() > index)
-                        isContinuity = isMidnight(bookings.get(index).getStartDate());
-                }
-                // 모두 수행
-                standard = b.getEndDate();
             }
-            return bookedDate;
+        }
+
+        return datesOfMonth.entrySet().stream()
+                // 예약이 모두 된 날짜 반환
+                .filter(entry -> entry.getValue() == 24)
+                .map(date -> DateTimeUtil.dateToString(date.getKey()))
+                .sorted()
+                .collect(Collectors.toList());
     }
 
-    private boolean isMidnight(LocalDateTime localDateTime) {
-        return DateTimeUtil.dateTimeToTime(localDateTime).equals(LocalTime.MIN);
+    private Map<LocalDate, Integer> createDatesOfMonth(int year, Month month) {
+        return IntStream.rangeClosed(1, month.maxLength())
+                .mapToObj(day -> LocalDate.of(year, month, day))
+                .collect(Collectors.toMap(date -> date, date -> 0));
     }
 
     @Override


### PR DESCRIPTION
## ✈️ 지라 티켓
- [PDS-155](https://pladi-alm.atlassian.net/browse/PDS-155) 월별 장비/차량 예약 불가능 날짜 조회 로직 수정

<br>

## 👾 작업 내용
- 예약 현황 조회 로직 수정
- `Map<LocalDate, Integer>` 바탕으로 해당 날짜의 시간이 예약될 때마다 +1 -> 24시간 모두 예약된 날짜 반환
(아이디어 감사링- @psyeon1120 @chaerlo127 )
- 예약 관련 조회 시, 예약 완료된 것까지 고려하도록 변경

<br>

## 📸 스크린샷

<br>

## 🎸 기타 사항
|예약시작시간|예약종료시간|
|---|---|
|11.30 17|12.02 02|
|12.12 00|12.15 15|
|12.15 13|12.15 15|
|12.15 15|12.16 03|
|12.16 03|12.17 00|
|12.17 05|12.19 01|

-> 이 케이스 테스트 완


[PDS-155]: https://pladi-alm.atlassian.net/browse/PDS-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ