### PR TITLE
[PDS-171/fix] 테스트 코드 실행시 db에 저장되고 동시에 rollback되도록 수정

### DIFF
--- a/src/main/java/com/example/pladialmserver/equipment/dto/request/UpdateEquipmentReq.java
+++ b/src/main/java/com/example/pladialmserver/equipment/dto/request/UpdateEquipmentReq.java
@@ -30,4 +30,7 @@ public class UpdateEquipmentReq {
     private String category;
     @Schema(type = "String", description = "비품 이미지 키", example = "photo/maxim.png", required = true)
     private String imgKey;
+    @Schema(type = "Long", description = "비품 등록자", example = "1", required = true)
+    @NotNull(message = "E0003")
+    private Long userId;
 }

--- a/src/main/java/com/example/pladialmserver/equipment/dto/request/UpdateEquipmentReq.java
+++ b/src/main/java/com/example/pladialmserver/equipment/dto/request/UpdateEquipmentReq.java
@@ -30,7 +30,5 @@ public class UpdateEquipmentReq {
     private String category;
     @Schema(type = "String", description = "비품 이미지 키", example = "photo/maxim.png", required = true)
     private String imgKey;
-    @Schema(type = "Long", description = "비품 등록자", example = "1", required = true)
-    @NotNull(message = "E0003")
-    private Long userId;
+
 }

--- a/src/test/java/com/example/pladialmserver/global/IntegrationTestSupport.java
+++ b/src/test/java/com/example/pladialmserver/global/IntegrationTestSupport.java
@@ -1,9 +1,13 @@
 package com.example.pladialmserver.global;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @ActiveProfiles("test")
 @SpringBootTest
-public class IntegrationTestSupport {
+@Transactional
+@Rollback
+public abstract class IntegrationTestSupport {
 }


### PR DESCRIPTION
## ✈️ 지라 티켓
- [PDS-171](https://pladi-alm.atlassian.net/browse/PDS-171) 테스트 코드 실행시 db에 저장되고 동시에 rollback되도록 수정

<br>

## 👾 작업 내용
- 

<br>

## 📸 스크린샷

<br>

## 🎸 기타 사항
- 이제 yml에 설정 코드 안넣어도 데이터 쌓이지는 않을거에요


[PDS-171]: https://pladi-alm.atlassian.net/browse/PDS-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ